### PR TITLE
multirom: core: Fix permissions loss in workaround_mount_in_sh

### DIFF
--- a/rom_quirks.c
+++ b/rom_quirks.c
@@ -57,6 +57,11 @@ static void workaround_mount_in_sh(const char *path)
 
     fclose(f_in);
     fclose(f_out);
+
+    struct stat info;
+    stat(path, &info);
+    chmod(tmp_name, info.st_mode);
+
     rename(tmp_name, path);
     free(tmp_name);
 }


### PR DESCRIPTION
 * Restore the original permissions on the new written .sh

 * On some ROMs like Sony Stock, .sh files are also used
    to configure the USB modes for example.

 * Right now, the files where wrongly set to default rw-rw-rw-,
    breaking USB support inside secondary ROMs

Change-Id: Ie73c504d730a7e2e15a6ca2210fd889858cc362c
Signed-off-by: Adrian DC <radian.dc@gmail.com>