### PR TITLE
multirom: inject: Support ramdisk layouts with init.real

### DIFF
--- a/install_zip/prebuilt-uninstaller/scripts/clear_boot.sh
+++ b/install_zip/prebuilt-uninstaller/scripts/clear_boot.sh
@@ -39,15 +39,20 @@ case "$magic" in
         ;;
 esac
 
-if [ rd_cmpr == -1 ] || [ ! -f /tmp/boot/init ] ; then
+if [ rd_cmpr == -1 ] || [ ! -e /tmp/boot/init -a ! -L /tmp/boot/init ] ; then
     echo "Failed to extract ramdisk!"
     return 1
 fi
 
 # restore init
 if [ -e /tmp/boot/main_init ] ; then
-    rm /tmp/boot/init
-    mv /tmp/boot/main_init /tmp/boot/init
+    if [ -e /tmp/boot/init.real ] ; then
+        rm /tmp/boot/init.real
+        mv /tmp/boot/main_init /tmp/boot/init.real
+    else
+        rm /tmp/boot/init
+        mv /tmp/boot/main_init /tmp/boot/init
+    fi
 fi
 
 chmod 750 /tmp/boot/init

--- a/lib/inject.c
+++ b/lib/inject.c
@@ -51,21 +51,28 @@ static int get_img_trampoline_ver(struct bootimg *img)
 static int copy_rd_files(UNUSED const char *path, UNUSED const char *busybox_path)
 {
     char buf[256];
+    char path_init[64];
+
+    if (access(TMP_RD_UNPACKED_DIR "/init.real", F_OK) != -1) {
+        snprintf(path_init, sizeof(path_init), TMP_RD_UNPACKED_DIR "/init.real");
+    } else {
+        snprintf(path_init, sizeof(path_init), TMP_RD_UNPACKED_DIR "/init");
+    }
 
     if (access(TMP_RD_UNPACKED_DIR"/main_init", F_OK) < 0 &&
-        rename(TMP_RD_UNPACKED_DIR"/init", TMP_RD_UNPACKED_DIR"/main_init") < 0)
+        rename(path_init, TMP_RD_UNPACKED_DIR"/main_init") < 0)
     {
-        ERROR("Failed to move /init to /main_init!\n");
+        ERROR("Failed to move %s to /main_init!\n", path_init);
         return -1;
     }
 
     snprintf(buf, sizeof(buf), "%s/trampoline", mrom_dir());
-    if(copy_file(buf, TMP_RD_UNPACKED_DIR"/init") < 0)
+    if(copy_file(buf, path_init) < 0)
     {
-        ERROR("Failed to copy trampoline to /init!\n");
+        ERROR("Failed to copy trampoline to %s!\n", path_init);
         return -1;
     }
-    chmod(TMP_RD_UNPACKED_DIR"/init", 0750);
+    chmod(path_init, 0750);
 
     remove(TMP_RD_UNPACKED_DIR"/sbin/ueventd");
     remove(TMP_RD_UNPACKED_DIR"/sbin/watchdogd");


### PR DESCRIPTION
 * Detect the /init.real file from the primary ramdisk,
    and use it instead of the usual /init

Change-Id: I1ded0c3bd939da61af0aaf3d688247482c7e9035
Signed-off-by: Adrian DC <radian.dc@gmail.com>