### PR TITLE
multirom: trampoline: Fully handle /proc/cmdline outputs

### DIFF
--- a/trampoline/trampoline.c
+++ b/trampoline/trampoline.c
@@ -222,15 +222,24 @@ static int mount_and_run(struct fstab *fstab)
 static int is_charger_mode(void)
 {
     char buff[2048] = { 0 };
+    int charger_mode = 0;
 
     FILE *f = fopen("/proc/cmdline", "re");
     if(!f)
         return 0;
 
-    fgets(buff, sizeof(buff), f);
+    while (fgets(buff, sizeof(buff), f) != NULL)
+    {
+        if (strstr(buff, "androidboot.mode=charger") != NULL)
+        {
+            charger_mode = 1;
+            break;
+        }
+    }
+
     fclose(f);
 
-    return (strstr(buff, "androidboot.mode=charger") != NULL);
+    return charger_mode;
 }
 
 static void fixup_symlinks(void)


### PR DESCRIPTION
 * In cases where the cmdline would be multiline,
    /proc/cmdline should be fully analyzed

Change-Id: I251988330832665ab15d936c22bc35b8401f688d
Signed-off-by: Adrian DC <radian.dc@gmail.com>