### PR TITLE
multirom: Fix /data/media/0 media linkage for SDCardFS

### DIFF
--- a/multirom.c
+++ b/multirom.c
@@ -1771,11 +1771,16 @@ int multirom_create_media_link(struct multirom_status *s)
         if(!media_new) from = 0;
         else           from = 1;
     }
-    else if(api_level >= 17)
+    else if(api_level <= 22)
     {
         from = 0;
         if(!media_new) to = 3;
         else           to = 2;
+    }
+    else
+    {
+        from = 0;
+        to = 2;
     }
 
     ERROR("Making media dir: api %d, media_new %d, %s to %s\n", api_level, media_new, paths[from], paths[to]);


### PR DESCRIPTION
 * In a MultiROM environment, /data is owned by the
    booted secondary ROM, specifically it can even be
    part of an external MicroSD (for example with EXT4)

 * By using a ROM supporting SDCardFS, the interal
    media storage will be accessed through its driver,
    but the fact /data/media/0 could be used under
    specific conditions means the /data/media mounts
    used by the emulated storage loop through:
     - /data/media (external ROM)
     - /data/media/0 (internal storage)

 * SDCardFS prevents "cross-device" linkage by
    returning -EXDEV, breaking internal storage access

 * Always use the proper /data/media path on newer APIs
    to avoid any cross-device linkage of internal storage,
    and preserve old handling up to API 22 (Android 5.1)

Change-Id: Ib49db68eede289d3943b9537d542eef5082e3118
Signed-off-by: Adrian DC <radian.dc@gmail.com>